### PR TITLE
Porting into latest version of transformers & torch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-torch==1.7.0
+torch==1.9.0
 nltk==3.4.5
 colorama==0.4.4
-transformers==3.4.0
+transformers==4.11.3
 torchtext==0.3.1


### PR DESCRIPTION
Hi,

Recently I've been working on Conditional Text Generation for [2021 OSAM Hackathon](https://github.com/osamhack2021?q=pplm&type=&language=&sort=) in Korea,
[Our team](https://github.com/osamhack2021/AI_WEB_POOL_YD) tried your paper code, in order to generate some sentences suitable for job application resume,
and during the process we had to do some modification to match our dependencies.

Here I'd like to share the outcomes, with support to latest version of `torch` and `transformers`,
although this version only takes care of PPLM-BOW (i.e. irrelevant dependencies like `torchtext` might cause some errors when trying out PPLM-DISCRIM or so).
BOW scenario was fully tested and seems to be working well.

The main consideration was the discrepancy of input and output schema of `transformers.GPT2LMHeadModel`.
With older version, `past` values would encapsulate query & key tensors (of attention layers) in the same large tensor,
but now they're seperated into tuples, demanding a deeper method for adding two past tensors.

Anyway, just for someone who'd be interested in bringing your awesome works into current projects.

thx!